### PR TITLE
update gems for nokogiri vuln

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-ruby '2.5.1'
+ruby '2.5.3'
 
 gem 'rake', '~> 10.1.0'
 gem 'sinatra', '~> 2.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,30 +1,30 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.5.0)
-      public_suffix (~> 2.0, >= 2.0.2)
-    capybara (2.10.1)
+    addressable (2.6.0)
+      public_suffix (>= 2.0.2, < 4.0)
+    capybara (2.10.2)
       addressable
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
-    diff-lcs (1.2.5)
+    diff-lcs (1.3)
     docile (1.1.5)
     foreman (0.78.0)
       thor (~> 0.19.1)
     json (2.1.0)
-    mime-types (3.1)
+    mime-types (3.2.2)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2016.0521)
-    mini_portile2 (2.3.0)
+    mime-types-data (3.2018.0812)
+    mini_portile2 (2.4.0)
     mustermann (1.0.3)
-    nokogiri (1.8.2)
-      mini_portile2 (~> 2.3.0)
-    public_suffix (2.0.3)
+    nokogiri (1.10.1)
+      mini_portile2 (~> 2.4.0)
+    public_suffix (3.0.3)
     rack (2.0.6)
-    rack-protection (2.0.4)
+    rack-protection (2.0.5)
       rack
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -48,14 +48,14 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
-    sinatra (2.0.4)
+    sinatra (2.0.5)
       mustermann (~> 1.0)
       rack (~> 2.0)
-      rack-protection (= 2.0.4)
+      rack-protection (= 2.0.5)
       tilt (~> 2.0)
-    thor (0.19.1)
-    tilt (2.0.8)
-    xpath (2.0.0)
+    thor (0.19.4)
+    tilt (2.0.9)
+    xpath (2.1.0)
       nokogiri (~> 1.3)
 
 PLATFORMS
@@ -72,7 +72,7 @@ DEPENDENCIES
   sinatra (~> 2.0.0)
 
 RUBY VERSION
-   ruby 2.5.1p57
+   ruby 2.5.3p105
 
 BUNDLED WITH
    1.16.1


### PR DESCRIPTION
Gem updates as available due to nokogiri vuln: https://nvd.nist.gov/vuln/detail/CVE-2018-14404